### PR TITLE
feat: swagger v3, hapi v18, hapi-swager v10

### DIFF
--- a/packages/js-graphql-server/package.json
+++ b/packages/js-graphql-server/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "apollo-server-hapi": "^2.0.5",
-    "boom": "^7.2.0",
+    "@hapi/boom": "^7.4.2",
     "graphql": "^14.0.0",
     "ipfs-rest-client": "^1.0.0"
   },

--- a/packages/js-http-server/package.json
+++ b/packages/js-http-server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "glue": "^5.0.0",
+    "@hapi/glue": "^6.1.0",
     "ipfs-rest-server": "^1.0.0",
     "ipfs-graphql-server": "^1.0.0"
   },

--- a/packages/js-http-server/server.js
+++ b/packages/js-http-server/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Glue = require('glue')
+const Glue = require('@hapi/glue')
 const manifest = {
   server: {
     host: 'localhost',

--- a/packages/js-rest-server/index.js
+++ b/packages/js-rest-server/index.js
@@ -5,8 +5,8 @@ const HapiSwagger = require('hapi-swagger')
 const routes = require('./routes')
 const IPFS = require('ipfs')
 const remote = require('ipfs-api')
-const Inert = require('inert')
-const Vision = require('vision')
+const Inert = require('@hapi/inert')
+const Vision = require('@hapi/vision')
 const log = require('debug')('ipfs:http:server')
 
 const getIpfs = async (options) => {
@@ -46,10 +46,9 @@ module.exports = {
           title: 'IPFS API Documentation',
           version: pkg.version,
         },
-        sortTags: 'name',
-        sortEndpoints: 'path',
-        definitionPrefix: 'useLabel',
-        jsonEditor: true
+        sortTags: 'alpha',
+        sortEndpoints: 'method',
+        definitionPrefix: 'useLabel'
       }
     }])
 

--- a/packages/js-rest-server/package.json
+++ b/packages/js-rest-server/package.json
@@ -11,13 +11,13 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.6.1",
-    "boom": "^7.2.0",
+    "@hapi/boom": "^7.4.2",
     "cids": "~0.5.3",
-    "hapi-swagger": "achingbrain/hapi-swagger#remove-type-from-arrays-with-item-ref",
-    "inert": "^5.1.0",
+    "hapi-swagger": "~10.0.0",
+    "@hapi/inert": "^5.2.0",
     "ipfs": "~0.31.7",
     "multihashes": "~0.4.14",
-    "vision": "^5.3.3"
+    "@hapi/vision": "^5.5.2"
   },
   "devDependencies": {
     "aegir": "^15.1.0"

--- a/packages/js-rest-server/routes/files/get.js
+++ b/packages/js-rest-server/routes/files/get.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const Boom = require('boom')
+const Boom = require('@hapi/boom')
 const CID = require('cids')
 const {
   JSON,


### PR DESCRIPTION
I needed to bump the the hapi-swagger fork to get this to run, and then started on ill-advised hapi upgrade. It works! and gets rid of all the annoying hapi deprecation warnings, but the new swagger docs are kinda gross. What are they playing at?

<img width="1551" alt="Screenshot 2019-06-14 at 22 52 09" src="https://user-images.githubusercontent.com/58871/59540920-24fae700-8ef7-11e9-9e5f-b15da6433274.png">

_sigh_

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>